### PR TITLE
fix check typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OPTS=	-ldflags="-s -w" -v
 
 all: checks ${BIN}
 
-checks:
+check:
 	@V=`go version|cut -d' ' -f 3| sed 's/^go//'` && \
 	if test "x$$V" \< "x1.8" ; then \
 		echo "You must have go 1.8+"; \
@@ -39,7 +39,7 @@ ${BIN}: ${SRCS} ${USRC}
 ${EXE}: ${SRCS} ${WSRC}
 	GOOS=windows go build ${OPTS} ./cmd/...
 
-test: checks
+test: check
 	go test -v ./...
 
 install: check ${BIN}

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ EXE=	${BIN}.exe
 
 OPTS=	-ldflags="-s -w" -v
 
-all: checks ${BIN}
+all: check ${BIN}
 
 check:
 	@V=`go version|cut -d' ' -f 3| sed 's/^go//'` && \


### PR DESCRIPTION
There is 'check' and 'checks' in the Makefile.
make install depends on check but it doesn't exist.

In this PR, I'd suggest replacing all 'checks' by 'check'.