### PR TITLE
Get my measurements when passing mine=true opts parameter

### DIFF
--- a/measurements.go
+++ b/measurements.go
@@ -58,9 +58,13 @@ type measurementList struct {
 func (c *Client) fetchOneMeasurementPage(opts map[string]string) (raw *measurementList, err error) {
 	opts = c.addAPIKey(opts)
 	c.mergeGlobalOptions(opts)
-	req := c.prepareRequest("GET", "measurements", opts)
+	path := "measurements"
+	if opts["mine"] == "true" {
+		path = "measurements/my"
+	}
+	req := c.prepareRequest("GET", path, opts)
 
-	//log.Printf("req=%s qp=%#v", MeasurementEP, opts)
+	//log.Printf("req=%s qp=%#v", req, opts)
 	resp, err := c.call(req)
 	if err != nil {
 		_, err = c.handleAPIResponse(resp)


### PR DESCRIPTION
For some reasons, the RIPE Atlas API docs say that the mine=true parameter should only returns your measurements.
After some tests using curl, this seems wrong. The API path for is `/measurements/my/`, see https://atlas.ripe.net/docs/apis/rest-api-reference/#measurements. Instead of creating a dedicated API, I thought that I could hack it by adding a switch. 